### PR TITLE
python: fix missed translation for exception namespace_state_not_found_error

### DIFF
--- a/bindings/python/main.cpp
+++ b/bindings/python/main.cpp
@@ -34,7 +34,7 @@ namespace bp = boost::python;
 namespace mm = mastermind;
 
 namespace mastermind {
-namespace binding { 
+namespace binding {
 
 class gil_guard_t {
 public:
@@ -566,6 +566,9 @@ init_exception_translator() {
 	auto *mastermind_cache_error
 		= exception::make_exception_class("MastermindCacheError");
 
+	//IMPORTANT: ensure that the following exception list is in sync with
+	// the exception list in include/libmastermind/error.hpp
+
 	exception::register_exception_translator<mm::couple_not_found_error>(
 			"CoupleNotFoundError", mastermind_cache_error);
 
@@ -595,6 +598,9 @@ init_exception_translator() {
 
 	exception::register_exception_translator<mm::unknown_groupset_error>(
 			"UnknownGroupsetError", mastermind_cache_error);
+
+	exception::register_exception_translator<mm::namespace_state_not_found_error>(
+			"NamespaceNotFoundError", mastermind_cache_error);
 
 	exception::register_exception_translator<mm::remotes_empty_error>(
 			"RemotesEmptyError", mastermind_cache_error);

--- a/include/libmastermind/error.hpp
+++ b/include/libmastermind/error.hpp
@@ -51,6 +51,9 @@ const std::error_category &libmastermind_category();
 std::error_code make_error_code(libmastermind_error::libmastermind_error_t e);
 std::error_condition make_error_condition(libmastermind_error::libmastermind_error_t e);
 
+//IMPORTANT: ensure that the following exception list is in sync with
+// the exception list in bindings/python/main.cpp:init_exception_translator()
+
 class couple_not_found_error
 	: public std::system_error
 {


### PR DESCRIPTION
Exception lists in `include/libmastermind/error.hpp` and `binding/python/main.cpp` must be in sync.
`namespace_state_not_found_error` was omitted in binding.